### PR TITLE
fix custom fields parsed as empty on new passwords

### DIFF
--- a/src/Converter/PasswordConverter.js
+++ b/src/Converter/PasswordConverter.js
@@ -34,7 +34,11 @@ export default class PasswordConverter extends AbstractConverter {
                 clone.customFields = this._customFieldConverter.fromArray([]);
             }
         } else {
-            clone.customFields = this._customFieldConverter.fromArray([]);
+            if(Array.isArray(clone.customFields) !== undefined && clone.customFields.length > 0) {
+                clone.customFields = this._customFieldConverter.fromArray(clone.customFields);
+            } else {
+                clone.customFields = this._customFieldConverter.fromArray([]);
+            }
         }
 
         if(clone.hasOwnProperty('created') && !(clone.created instanceof Date)) {

--- a/src/Converter/PasswordConverter.js
+++ b/src/Converter/PasswordConverter.js
@@ -34,7 +34,7 @@ export default class PasswordConverter extends AbstractConverter {
                 clone.customFields = this._customFieldConverter.fromArray([]);
             }
         } else {
-            if(Array.isArray(clone.customFields) !== undefined && clone.customFields.length > 0) {
+            if(Array.isArray(clone.customFields) && clone.customFields.length > 0) {
                 clone.customFields = this._customFieldConverter.fromArray(clone.customFields);
             } else {
                 clone.customFields = this._customFieldConverter.fromArray([]);


### PR DESCRIPTION
When creating a new password and adding custom fields during the initial creation, the custom fields are not parsed and an empty array is returned. This fixes this issue by allowing custom fields in a valid array format during the creation.

The issue was mentioned here: https://github.com/marius-wieschollek/passwords-webextension/pull/167